### PR TITLE
Migrate to AWS_ENDPOINT_URL

### DIFF
--- a/src/jobs.js
+++ b/src/jobs.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const awsSdk = require('aws-sdk');
-const localstackHost = `http://${process.env.LOCALSTACK_HOSTNAME}:${process.env.EDGE_PORT}`
+
+const endpoint = process.env.AWS_ENDPOINT_URL
+const s3 = new awsSdk.S3({endpoint: endpoint, s3ForcePathStyle: true});
 
 // This function is triggered by an HTTP request using the GET method.
 // The function returns a list of all the transcription jobs stored in the S3 bucket.
@@ -24,8 +26,6 @@ exports.list = async (event, context, callback) => {
     <br>
     </ul>
 `
-
-  const s3 = new awsSdk.S3({endpoint:localstackHost, s3ForcePathStyle: true});
 
   const bucketName = "aws-node-sample-transcribe-s3-local-transcriptions";
   const params = {

--- a/src/transcribe.js
+++ b/src/transcribe.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const awsSdk = require('aws-sdk');
-const localstackHost = `http://${process.env.LOCALSTACK_HOSTNAME}:${process.env.EDGE_PORT}`
-const endpoint = new awsSdk.Endpoint(localstackHost);
+
+const endpoint_url = process.env.AWS_ENDPOINT_URL
+const endpoint = new awsSdk.Endpoint(endpoint_url);
 const endpointConfig = new awsSdk.Config({
   endpoint: endpoint
 });


### PR DESCRIPTION
Adopt `AWS_ENDPOINT_URL` as the official endpoint variable introduced by AWS.

See https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/

/cc repo maintainer @sannya-singal 

## Suggested Follow-Up

It would be better to inject the QueueUrl as an environment variable as well (like for the `S3_TRANSCRIPTION_BUCKET` 👍 ).